### PR TITLE
Change default to OpenGL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Joël Lupien (Jojolepro) <jojolepro@jojolepro.com>"]
 edition = "2018"
 
 [features]
-default = ["terminal"]
+default = ["opengl"]
 terminal = ["minigene/terminal"]
 opengl = ["minigene/opengl"]
 wasm = ["wasm-bindgen", "minigene/wasm", "console_error_panic_hook"]


### PR DESCRIPTION
The terminal option isn't really necessary for anything other than the novelty factor and for individual users to hack on themselves. OpenGL works much more consistently across devices, so it's the saner default.