### PR TITLE
Change handle action points to use value_with_effectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
 [[package]]
 name = "minigene"
 version = "0.3.0"
+source = "git+https://github.com/jojolepro/minigene?branch=master#a112953c558aa3cf13a0beadfe2a43e8cd7ed7c2"
 dependencies = [
  "bracket-lib",
  "crossterm 0.18.2",

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,7 @@ fn main() -> BError {
     let mut dispatcher = DispatcherBuilder::new();
     dispatcher!(
         dispatcher,
+        reset_stat_effectors_system,
         combine_collision_system,
         input_driver::<InputEvent>,
         update_collision_resource_system,

--- a/src/systems/handle_action_points.rs
+++ b/src/systems/handle_action_points.rs
@@ -1,9 +1,8 @@
 use crate::*;
 
 pub fn handle_action_points_system(stats: &mut Components<StatSet<Stats>>) -> SystemResult {
-    // TODO consider using an effector instead?
     for stat in stats.iter_mut() {
-        let refill = stat.stats.get(&Stats::ActionPointRefillRate).unwrap().value;
+        let refill = stat.stats.get(&Stats::ActionPointRefillRate).unwrap().value_with_effectors;
         let stat = stat.stats.get_mut(&Stats::ActionPoints).unwrap();
         stat.value += refill;
         if stat.value >= 100.0 {

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,3 +1,4 @@
+mod reset_stat_effectors;
 mod aoe_damage;
 mod creep_spawner;
 mod damage_entity;
@@ -19,6 +20,7 @@ mod tower_projectile;
 mod update_collision_resource;
 mod update_enemies_around_stat;
 mod update_win_condition;
+pub use self::reset_stat_effectors::*;
 pub use self::aoe_damage::*;
 pub use self::creep_spawner::*;
 pub use self::damage_entity::*;

--- a/src/systems/reset_stat_effectors.rs
+++ b/src/systems/reset_stat_effectors.rs
@@ -1,0 +1,10 @@
+use crate::*;
+
+pub fn reset_stat_effectors_system(stats: &mut Components<StatSet<Stats>>) -> SystemResult {
+         for stat in stats.iter_mut() {
+            for mut s in stat.stats.values_mut() {
+                s.value_with_effectors = s.value;
+            }
+         }
+    Ok(())
+}


### PR DESCRIPTION
Add a `reset_stat_effectors` that enables the use of `value_with_effectors` of `ActionPointRefillRate` and consequently enables my tree-person leader implementation.