### PR TITLE
Very minor fine-tuning to OrderQueue

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -95,14 +95,16 @@ impl OrderQueue {
             orders: VecDeque::new(),
         }
     }
+}
 
-    /// Create OrderQueue with pre-existing vector of orders
-    pub fn from_vec(orders: Vec<UnitOrder>) -> Self {
+impl From<Vec<UnitOrder>> for OrderQueue {
+    fn from(orders: Vec<UnitOrder>) -> Self {
         OrderQueue {
             orders: VecDeque::from(orders),
         }
     }
 }
+
 /// Items available to buy
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub struct ShelfItem(pub Items, pub i32);

--- a/src/components.rs
+++ b/src/components.rs
@@ -89,8 +89,15 @@ pub struct OrderQueue {
 }
 
 impl OrderQueue {
-    /// Better to wrap a component creation in a function
-    pub fn new(orders: Vec<UnitOrder>) -> Self {
+    /// Create an empty OrderQueue
+    pub fn new() -> Self {
+        OrderQueue {
+            orders: VecDeque::new(),
+        }
+    }
+
+    /// Create OrderQueue with pre-existing vector of orders
+    pub fn from_vec(orders: Vec<UnitOrder>) -> Self {
         OrderQueue {
             orders: VecDeque::from(orders),
         }

--- a/src/systems/order_generation.rs
+++ b/src/systems/order_generation.rs
@@ -26,8 +26,10 @@ pub fn order_generation_system(
                             oq.orders.clear();
                             oq.orders.push_back(UnitOrder::MovetoPoint(*pos));
                         } else {
-                            order_queue
-                                .insert(*e, OrderQueue::new(vec![UnitOrder::MovetoPoint(*pos)]));
+                            order_queue.insert(
+                                *e,
+                                OrderQueue::from_vec(vec![UnitOrder::MovetoPoint(*pos)]),
+                            );
                         }
                     }
                 }
@@ -40,7 +42,7 @@ pub fn order_generation_system(
                         } else {
                             order_queue.insert(
                                 *e,
-                                OrderQueue::new(vec![UnitOrder::MovetoUnit(trg_e[0].clone())]),
+                                OrderQueue::from_vec(vec![UnitOrder::MovetoUnit(trg_e[0].clone())]),
                             );
                         }
                     }
@@ -51,8 +53,10 @@ pub fn order_generation_system(
                             oq.orders.clear();
                             oq.orders.push_back(UnitOrder::AMovetoPoint(*pos));
                         } else {
-                            order_queue
-                                .insert(*e, OrderQueue::new(vec![UnitOrder::AMovetoPoint(*pos)]));
+                            order_queue.insert(
+                                *e,
+                                OrderQueue::from_vec(vec![UnitOrder::AMovetoPoint(*pos)]),
+                            );
                         }
                     }
                 }
@@ -70,7 +74,7 @@ pub fn order_generation_system(
                         oq.orders.clear();
                         oq.orders.push_back(UnitOrder::HoldPosition);
                     } else {
-                        order_queue.insert(*e, OrderQueue::new(vec![UnitOrder::HoldPosition]));
+                        order_queue.insert(*e, OrderQueue::from_vec(vec![UnitOrder::HoldPosition]));
                     }
                 }
             }
@@ -80,7 +84,7 @@ pub fn order_generation_system(
                     if let Some(oq) = order_queue.get_mut(*e) {
                         oq.orders.clear();
                     } else {
-                        order_queue.insert(*e, OrderQueue::new(vec![]));
+                        order_queue.insert(*e, OrderQueue::new());
                     }
                 }
             }

--- a/src/systems/order_generation.rs
+++ b/src/systems/order_generation.rs
@@ -26,10 +26,8 @@ pub fn order_generation_system(
                             oq.orders.clear();
                             oq.orders.push_back(UnitOrder::MovetoPoint(*pos));
                         } else {
-                            order_queue.insert(
-                                *e,
-                                OrderQueue::from_vec(vec![UnitOrder::MovetoPoint(*pos)]),
-                            );
+                            order_queue
+                                .insert(*e, OrderQueue::from(vec![UnitOrder::MovetoPoint(*pos)]));
                         }
                     }
                 }
@@ -42,7 +40,7 @@ pub fn order_generation_system(
                         } else {
                             order_queue.insert(
                                 *e,
-                                OrderQueue::from_vec(vec![UnitOrder::MovetoUnit(trg_e[0].clone())]),
+                                OrderQueue::from(vec![UnitOrder::MovetoUnit(trg_e[0].clone())]),
                             );
                         }
                     }
@@ -53,10 +51,8 @@ pub fn order_generation_system(
                             oq.orders.clear();
                             oq.orders.push_back(UnitOrder::AMovetoPoint(*pos));
                         } else {
-                            order_queue.insert(
-                                *e,
-                                OrderQueue::from_vec(vec![UnitOrder::AMovetoPoint(*pos)]),
-                            );
+                            order_queue
+                                .insert(*e, OrderQueue::from(vec![UnitOrder::AMovetoPoint(*pos)]));
                         }
                     }
                 }
@@ -74,7 +70,7 @@ pub fn order_generation_system(
                         oq.orders.clear();
                         oq.orders.push_back(UnitOrder::HoldPosition);
                     } else {
-                        order_queue.insert(*e, OrderQueue::from_vec(vec![UnitOrder::HoldPosition]));
+                        order_queue.insert(*e, OrderQueue::from(vec![UnitOrder::HoldPosition]));
                     }
                 }
             }

--- a/src/systems/spawn_creep.rs
+++ b/src/systems/spawn_creep.rs
@@ -34,7 +34,7 @@ pub fn spawn_creep_system(
 
             // Spawn with Hold position order. To stop leaders when game mode is changed to micro-input.
             // order_queue.insert(creep, OrderQueue::new(vec![UnitOrder::HoldPosition]));
-            order_queue.insert(creep, OrderQueue::new(vec![]));
+            order_queue.insert(creep, OrderQueue::new());
 
             sprites.insert(
                 creep,

--- a/src/systems/spawn_leader.rs
+++ b/src/systems/spawn_leader.rs
@@ -59,7 +59,7 @@ pub fn spawn_leader_system(
 
             // Spawn with Hold position order. To stop leaders when game mode is changed to micro-input.
             // order_queue.insert(leader, OrderQueue::new(vec![UnitOrder::HoldPosition]));
-            order_queue.insert(leader, OrderQueue::new(vec![]));
+            order_queue.insert(leader, OrderQueue::new());
 
             skillsets.insert(
                 leader,


### PR DESCRIPTION
It seemed inconsistent that `OrderQueue` component which is based on `VecDeque` would be created by supplying `Vec` of values. This tiny PR fixes it.

(I was hoping to commit it to #49 before it was merged, but it seems like I was 3 hours  too slow)